### PR TITLE
PCM-2238 ends server logging if we get a 401

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -156,7 +156,7 @@ export interface LoggerEvents {
   onStop: StopReason;
 }
 
-export type StopReason = 401 | 404 | 'force';
+export type StopReason = 401 | 404 | '401' | '404' | 'force';
 export interface ITrace {
   topic: string;
   level: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -156,7 +156,7 @@ export interface LoggerEvents {
   onStop: StopReason;
 }
 
-export type StopReason = '401' | '404' | 'force';
+export type StopReason = 401 | 404 | 'force';
 export interface ITrace {
   topic: string;
   level: string;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -60,7 +60,7 @@ export class Logger extends (EventEmitter as { new(): StrictEventEmitter<EventEm
     this.config.accessToken = token;
 
     /* if we stopped because of a 401, we will try to start again */
-    if (this.stopReason === '401') {
+    if (this.stopReason === 401) {
       this.startServerLogging();
     }
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -60,7 +60,7 @@ export class Logger extends (EventEmitter as { new(): StrictEventEmitter<EventEm
     this.config.accessToken = token;
 
     /* if we stopped because of a 401, we will try to start again */
-    if (this.stopReason === 401) {
+    if (this.stopReason == 401) {
       this.startServerLogging();
     }
   }

--- a/src/server-logger.ts
+++ b/src/server-logger.ts
@@ -175,9 +175,13 @@ export class ServerLogger {
       this.logger.emit('onError', err);
       this.logger.error('Error sending logs to server', err, { skipServer: true });
       /* no-op: the uploader will attempt reties. if the uploader throws, it means this log isn't going to make to the server */
-      const statusCode = err?.response?.status as 401 | 404;
 
-      if ([401, 404].includes(statusCode)) {
+      /* TODO: figure out why the error structure changed and determine if this is necessary */
+      const statusCode = err?.status
+      ? err?.status as 401 | 404 | '401' | '404'
+        : err?.response?.status as 401 | 404 | '401' | '404';
+
+      if ([401, 404, '401', '404'].includes(statusCode)) {
         this.debug(`received a ${statusCode} from logUploader. stopping logging to server`);
         this.logger.stopServerLogging();
       }

--- a/src/server-logger.ts
+++ b/src/server-logger.ts
@@ -171,15 +171,15 @@ export class ServerLogger {
       // this.pendingHttpRequest = true;
       this.debug('calling logUploader.postLogsToEndpoint() with', { bufferItem, newLogBuffer: this.logBuffer });
       await this.logUploader.postLogsToEndpoint(this.convertToRequestParams(bufferItem.traces.reverse()));
-    } catch (err) {
+    } catch (err: any) {
       this.logger.emit('onError', err);
       this.logger.error('Error sending logs to server', err, { skipServer: true });
       /* no-op: the uploader will attempt reties. if the uploader throws, it means this log isn't going to make to the server */
-      const statusCode = `${(err as any)?.status}` as '401' | '404';
+      const statusCode = err?.response?.status as 401 | 404;
 
-      if (['401', '404'].includes(statusCode)) {
+      if ([401, 404].includes(statusCode)) {
         this.debug(`received a ${statusCode} from logUploader. stopping logging to server`);
-        this.logger.stopServerLogging(statusCode);
+        this.logger.stopServerLogging();
       }
     } finally {
       /* setup the debounce again */


### PR DESCRIPTION
checks error objects for proper types and structures to end server logging if a 401 is returned