### PR TITLE
[STREAM-950] Move away from `unload` to send logs at the end of a user's session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [STREAM-799](https://inindca.atlassian.net/browse/STREAM-799) - Updated axios to v1.10.0 to fix critical Snyk vulnerability.
 * [STREAM-800](https://inindca.atlassian.net/browse/STREAM-800) - Added GitHub Actions for linting, testing, and building in an effort to make the build process more transparent and reliable.
 * [STREAM-868](https://inindca.atlassian.net/browse/STREAM-868) - Generate a test report in JUnit.xml format.
+* [STREAM-950](https://inindca.atlassian.net/browse/STREAM-950) - Move away from `unload` to send logs at the end of a user's session.
 
 # [4.2.16](https://github.com/purecloudlabs/genesys-cloud-client-logger/compare/v4.2.15...4.2.16)
 ### Changed

--- a/src/log-uploader.ts
+++ b/src/log-uploader.ts
@@ -114,7 +114,7 @@ export class LogUploader {
       );
     }
 
-    /* don't want this to be async because this is called from the window 'unload' event */
+    /* don't want this to be async because this is called from the document 'visibilitychange' event */
     return promises;
   }
 

--- a/src/server-logger.ts
+++ b/src/server-logger.ts
@@ -131,7 +131,7 @@ export class ServerLogger {
   }
 
   sendAllLogsInstantly (): Promise<any>[] {
-    /* don't want this to be async because this is called from the window 'unload' event */
+    /* don't want this to be async because this is called from the document 'visibilitychange' event */
     /* this will send any queued up requests */
     return this.logUploader.sendEntireQueue()
       .concat(

--- a/src/server-logger.ts
+++ b/src/server-logger.ts
@@ -34,7 +34,11 @@ export class ServerLogger {
     this.debounceLogUploadTime = logger.config.uploadDebounceTime || DEFAULT_UPLOAD_DEBOUNCE;
     this.logUploader = getOrCreateLogUploader(logger.config.url, logger.config.debugMode, logger.config.useUniqueLogUploader, logger.config.customHeaders);
 
-    window.addEventListener('unload', this.sendAllLogsInstantly.bind(this));
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        this.sendAllLogsInstantly();
+      }
+    });
 
     /* when we stop server logging, we need to clear everything out */
     this.logger.on('onStop', (_reason) => {

--- a/tests/server-logger.test.ts
+++ b/tests/server-logger.test.ts
@@ -59,20 +59,47 @@ describe('ServerLogger', () => {
 
     it('should set config to passed in options', () => {
       logger.config.uploadDebounceTime = 14000;
-      jest.spyOn(window, 'addEventListener').mockImplementation();
+      const eventListenerSpy = jest.spyOn(document, 'addEventListener');
 
       serverLogger = new ServerLogger(logger);
 
       expect(serverLogger['logger']).toBe(logger);
       expect(serverLogger['debounceLogUploadTime']).toBe(14000);
       expect(serverLogger['logUploader']).toBe(getOrCreateLogUploader(config.url));
-      expect(window.addEventListener).toHaveBeenCalledWith('unload', expect.any(Function));
+      expect(eventListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
+
+      eventListenerSpy.mockRestore();
     });
 
     it('should set defaults', () => {
       expect(serverLogger['logger']).toBe(logger);
       expect(serverLogger['debounceLogUploadTime']).toBe(4000);
       expect(serverLogger['logUploader']).toBe(getOrCreateLogUploader(config.url));
+    });
+
+    it('should only call sendAllLogsInstantly when the visibilityState is hidden', () => {
+      const eventListenerSpy = jest.spyOn(document, 'addEventListener');
+      serverLogger = new ServerLogger(logger);
+      const sendLogsSpy = serverLogger.sendAllLogsInstantly = jest.fn();
+      const visibilityHandler = eventListenerSpy.mock.calls[0][1] as EventListener;
+      const visibilityEvent = new Event('visibilitychange');
+
+      Object.defineProperty(document, 'visibilityState', {
+        writable: true,
+        value: 'visible'
+      });
+      visibilityHandler(visibilityEvent);
+      expect(sendLogsSpy).not.toHaveBeenCalled();
+
+      Object.defineProperty(document, 'visibilityState', {
+        writable: true,
+        value: 'hidden'
+      });
+      visibilityHandler(visibilityEvent);
+      expect(sendLogsSpy).toHaveBeenCalled();
+
+      eventListenerSpy.mockRestore();
+      sendLogsSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
Let me know if you know a better or more appropriate way to change this. My research suggested this was a good alternative (links in the ticket with a little commentary).

I updated comments, although I'm not sure if they're as accurate with this event as they were with `unload`. Additionally, I think it's worth considering using [`sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon), but it didn't seem strictly necessary for this ticket. I created a ticket to that effect, though: https://inindca.atlassian.net/browse/STREAM-951